### PR TITLE
nrzled: Don't set NoCS

### DIFF
--- a/nrzled/nrzled.go
+++ b/nrzled/nrzled.go
@@ -90,7 +90,7 @@ func NewSPI(p spi.Port, opts *Opts) (*Dev, error) {
 			return nil, errors.New("spi port buffer is too short for the specified number of pixels")
 		}
 	}
-	c, err := p.Connect(spiFreq, spi.Mode3|spi.NoCS, 8)
+	c, err := p.Connect(spiFreq, spi.Mode3, 8)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Whether or not CS (chip select) is used really depends on the way how
you wire things together, not on the device you're talking to.

Not using CS (and explicitly telling the SPI controller about that)
might keep some pins free on pin-constrained boards, but also, some
controllers (or Linux drivers) don't support disabling CS, and fail when
that flag is given.

On the other hand, even though nrzleds don't make use of CS by
themselves, you could very well have some circuit in front to do the
chip select, and then actually write to different nrzled devices
sequentially.

Long-term, the fact on whether to do chip select should be specified
while passing in the SPI port to be used, as it really depends on the
way it's wired together on the specific board, not on the type of
device.