### PR TITLE
Prevent WaitForEdge() returning early after first call to selectCard()

### DIFF
--- a/mfrc522/commands/low_level.go
+++ b/mfrc522/commands/low_level.go
@@ -226,6 +226,11 @@ func (r *LowLevel) WaitForEdge(timeout time.Duration) error {
 	}
 }
 
+// ClearInterrupt removes any pending host interrupts
+func (r *LowLevel) ClearInterrupt() {
+	r.irqPin.WaitForEdge(0)
+}
+
 // Auth authenticate the card fof the sector/block using the provided data.
 //
 // 	mode - the authentication mode.

--- a/mfrc522/mfrc522.go
+++ b/mfrc522/mfrc522.go
@@ -388,6 +388,8 @@ func (r *Dev) selectCard(timeout time.Duration) ([]byte, error) {
 	if err := r.LowLevel.Init(); err != nil {
 		return nil, err
 	}
+	defer r.LowLevel.ClearInterrupt()
+
 	if _, err := r.request(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Calling LowLevel.Init() in selectCard() clears the device interrupt
as a side effect, but another interrupt will occur due to the
subsquent operations. This additional host interrupt must be cleared
before the next call to selectCard.

https://github.com/google/periph/issues/425