### PR TITLE
[TLV493D] Method to calibrate temperature offset

### DIFF
--- a/tlv493d/tlv493d_test.go
+++ b/tlv493d/tlv493d_test.go
@@ -326,6 +326,17 @@ func TestTLV493D_Configuration(t *testing.T) {
 	}
 }
 
+func Test_TLV493D_TemperatureCalibration(t *testing.T) {
+	measure := 25*physic.Celsius + physic.ZeroCelsius
+	actual := 19*physic.Celsius + physic.ZeroCelsius
+	offset := CalibrateTemperatureOffsetCompensation(DefaultTemperatureOffsetCompensation, measure, actual)
+	expectedOffset := 345
+
+	if offset != expectedOffset {
+		t.Fatalf("Temperature offset: Found %d, expected %d", offset, expectedOffset)
+	}
+}
+
 func assertSample(t *testing.T, expected Sample, actual Sample) {
 	if actual.Bx != expected.Bx {
 		t.Fatalf("Bx: Found %d, expected %d", actual.Bx, expected.Bx)


### PR DESCRIPTION
Hello,

This is an addition to the TLV493D driver, in order to calibrate the "temperature offset". According to the [documentation](https://www.infineon.com/dgdl/Infineon-TLV493D-A1B6_3DMagnetic-UM-v01_03-EN.pdf?fileId=5546d46261d5e6820161e75721903ddd), section 3.2 "Calculation of the temperature", there is an Offset compensation, with a note: "The 340 as typical value may vary from device to device. Therefore for an accurate measurement the value at 25°C needs to be readout first and used as (correction) value instead of 340."

So this PR is basically the implementation of this.

Thanks!
Benjamin