### PR TITLE
[Inky] autodetect board opts and pHAT v2 support

### DIFF
--- a/inky/doc.go
+++ b/inky/doc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package inky drives an Inky pHAT or wHAT E ink display.
+// Package inky drives an Inky pHAT, pHAT v2 or wHAT E ink display.
 //
 // Datasheet
 //

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -69,12 +69,15 @@ type Model int
 const (
 	PHAT Model = iota
 	WHAT
+	PHAT2
 )
 
 func (m *Model) String() string {
 	switch *m {
 	case PHAT:
 		return "PHAT"
+	case PHAT2:
+		return "PHAT2"
 	case WHAT:
 		return "WHAT"
 	default:
@@ -87,6 +90,8 @@ func (m *Model) Set(s string) error {
 	switch s {
 	case "PHAT":
 		*m = PHAT
+	case "PHAT2":
+		*m = PHAT2
 	case "WHAT":
 		*m = WHAT
 	default:
@@ -147,6 +152,9 @@ func New(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinIn, o *Opts
 	switch o.Model {
 	case PHAT:
 		d.bounds = image.Rect(0, 0, 104, 212)
+		d.flipVertically = true
+	case PHAT2:
+		d.bounds = image.Rect(0, 0, 122, 250)
 		d.flipVertically = true
 	case WHAT:
 		d.bounds = image.Rect(0, 0, 400, 300)

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -14,7 +14,6 @@ import (
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/display"
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/i2c"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"
@@ -113,7 +112,7 @@ type Opts struct {
 	BorderColor Color
 }
 
-// DetectOpts tries to read the device opts from EEPROM, it is recommended to use I2C bus '1'.
+// DetectOpts tries to read the device opts from EEPROM.
 func DetectOpts(bus i2c.Bus) (*Opts, error) {
 	// Read data from EEPROM
 	data, err := readEep(bus)
@@ -201,21 +200,6 @@ func New(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinIn, o *Opts
 	}
 
 	return d, nil
-}
-
-// NewDetected tries to open a handle to an Inky pHat or wHAT automatically detected from EEPROM.
-// For a Raspberry Pi running linux the SPI port will usually be 'SPI0.0' and I2C bus '1'.
-func NewDetected(port spi.Port, bus i2c.Bus) (*Dev, error) {
-	opts, err := DetectOpts(bus)
-	if err != nil {
-		return nil, err
-	}
-
-	dcPin := gpioreg.ByName("22")
-	resetPin := gpioreg.ByName("27")
-	busyPin := gpioreg.ByName("17")
-
-	return New(port, dcPin, resetPin, busyPin, opts)
 }
 
 // Dev is a handle to an Inky.


### PR DESCRIPTION
I have added auto opts detect and dev struct creationg with defaults from the detected opts as mentioned in #11.

While I was at it I also added support for pHAT v2 which is simply a pHAT with a [small resolution difference](https://github.com/pimoroni/inky/blob/85f97ffa9ae775d4de71d5179af792ccb7080ee0/library/inky/phat.py#L15).

