### PR TITLE
ssd1306: Add SetDisplayStartLine

### DIFF
--- a/ssd1306/ssd1306.go
+++ b/ssd1306/ssd1306.go
@@ -279,6 +279,17 @@ func (d *Dev) SetContrast(level byte) error {
 	return d.sendCommand([]byte{0x81, level})
 }
 
+// SetDisplayStartLine causes the display to start from startLine, effectively
+// scrolling the screen to that position.
+//
+// startLine must be between 0 and 63.
+func (d *Dev) SetDisplayStartLine(startLine byte) error {
+	if startLine > 63 {
+		return fmt.Errorf("ssd1306: invalid startLine %d", startLine)
+	}
+	return d.sendCommand([]byte{_SETSTARTLINE | startLine})
+}
+
 // Halt turns off the display.
 //
 // Sending any other command afterward reenables the display.

--- a/ssd1306/ssd1306_test.go
+++ b/ssd1306/ssd1306_test.go
@@ -377,6 +377,37 @@ func TestI2C_SetContrast(t *testing.T) {
 	}
 }
 
+func TestI2C_SetDisplayStartLine(t *testing.T) {
+	bus := i2ctest.Playback{
+		Ops: []i2ctest.IO{
+			{Addr: 0x3c, W: initCmdI2C()},
+			{Addr: 0x3c, W: []byte{0x0, 0x40}},
+			{Addr: 0x3c, W: []byte{0x0, 0x45}},
+			{Addr: 0x3c, W: []byte{0x0, 0x60}},
+			{Addr: 0x3c, W: []byte{0x0, 0x7F}},
+		},
+	}
+	dev, err := NewI2C(&bus, &DefaultOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.SetDisplayStartLine(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.SetDisplayStartLine(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.SetDisplayStartLine(32); err != nil {
+		t.Fatal(err)
+	}
+	if err := dev.SetDisplayStartLine(63); err != nil {
+		t.Fatal(err)
+	}
+	if err := bus.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestI2C_Invert_Halt_resume(t *testing.T) {
 	bus := i2ctest.Playback{
 		Ops: []i2ctest.IO{


### PR DESCRIPTION
This is useful for controlled, smooth, vertical scrolling (to new content, not a looping scroll like `Dev.Scroll`. This is 10.1.6 from page 36 of [the datasheet].

With double-buffering, a 128x32 ssd1306 can scroll indefinitely. This can be done by setting `Opts.H: 64` (which does unfortunately dim the display a little bit), and using the lower 32 lines (which are off-screen) as a second image buffer.

[the datasheet]: https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf
