### PR TITLE
waveshare2in13v2: Remove dependencies on fogleman/gg and golang/freetype

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ module periph.io/x/devices/v3
 go 1.13
 
 require (
-	github.com/fogleman/gg v1.3.0
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/maruel/ansi256 v1.0.2
 	github.com/mattn/go-colorable v0.1.11
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
-github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/maruel/ansi256 v1.0.2 h1:AE5gYrrZ5vQaFTTwy5vxva8Bak7p7wID3Uqu3t1j3No=

--- a/waveshare2in13v2/example_test.go
+++ b/waveshare2in13v2/example_test.go
@@ -13,10 +13,6 @@ import (
 	"golang.org/x/image/font/basicfont"
 	"golang.org/x/image/math/fixed"
 
-	"github.com/fogleman/gg"
-	"github.com/golang/freetype/truetype"
-	"golang.org/x/image/font/gofont/goregular"
-
 	"periph.io/x/conn/v3/spi/spireg"
 	"periph.io/x/devices/v3/ssd1306/image1bit"
 	"periph.io/x/devices/v3/waveshare2in13v2"
@@ -87,42 +83,46 @@ func Example_other() {
 	}
 
 	var img image.Image
-	bounds := dev.Bounds()
-	w := bounds.Dx()
-	h := bounds.Dy()
-	dc := gg.NewContext(w, h)
-	im, err := gg.LoadPNG("gopher.png")
-	if err != nil {
-		panic(err)
-	}
-	dc.SetRGB(1, 1, 1)
-	dc.Clear()
-	dc.SetRGB(0, 0, 0)
-	dc.Rotate(gg.Radians(90))
-	dc.Translate(0.0, -float64(h/2))
-	font, err := truetype.Parse(goregular.TTF)
-	if err != nil {
-		panic(err)
-	}
-	face := truetype.NewFace(font, &truetype.Options{
-		Size: 16,
-	})
-	dc.SetFontFace(face)
-	text := "Hello from periph!"
-	tw, th := dc.MeasureString(text)
-	dc.DrawImage(im, 120, 30)
-	padding := 8.0
-	dc.DrawRoundedRectangle(padding*2, padding*2, tw+padding*2, th+padding, 10)
-	dc.Stroke()
-	dc.DrawString(text, padding*3, padding*2+th)
-	for i := 0; i < 10; i++ {
-		dc.DrawCircle(float64(30+(10*i)), 100, 5)
-	}
-	for i := 0; i < 10; i++ {
-		dc.DrawRectangle(float64(30+(10*i)), 80, 5, 5)
-	}
-	dc.Fill()
-	img = dc.Image()
+	// Note: this code is commented out so periph does not depend on:
+	//    "github.com/fogleman/gg"
+	//    "github.com/golang/freetype/truetype"
+	//    "golang.org/x/image/font/gofont/goregular"
+	// bounds := dev.Bounds()
+	// w := bounds.Dx()
+	// h := bounds.Dy()
+	// dc := gg.NewContext(w, h)
+	// im, err := gg.LoadPNG("gopher.png")
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// dc.SetRGB(1, 1, 1)
+	// dc.Clear()
+	// dc.SetRGB(0, 0, 0)
+	// dc.Rotate(gg.Radians(90))
+	// dc.Translate(0.0, -float64(h/2))
+	// font, err := truetype.Parse(goregular.TTF)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// face := truetype.NewFace(font, &truetype.Options{
+	// 	Size: 16,
+	// })
+	// dc.SetFontFace(face)
+	// text := "Hello from periph!"
+	// tw, th := dc.MeasureString(text)
+	// dc.DrawImage(im, 120, 30)
+	// padding := 8.0
+	// dc.DrawRoundedRectangle(padding*2, padding*2, tw+padding*2, th+padding, 10)
+	// dc.Stroke()
+	// dc.DrawString(text, padding*3, padding*2+th)
+	// for i := 0; i < 10; i++ {
+	// 	dc.DrawCircle(float64(30+(10*i)), 100, 5)
+	// }
+	// for i := 0; i < 10; i++ {
+	// 	dc.DrawRectangle(float64(30+(10*i)), 80, 5, 5)
+	// }
+	// dc.Fill()
+	// img = dc.Image()
 
 	if err := dev.Draw(dev.Bounds(), img, image.Point{}); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The waveshare2in13v2 example was evidently copied from the epd example,
but didn't comment out the code pulling in additional dependencies.