### PR TITLE
Bump Go version in go.mod and for quick tests to 1.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        gover: ['1.13.15']
+        gover: ['1.14.15']
     runs-on: "${{matrix.os}}"
     name: "go${{matrix.gover}} on ${{matrix.os}} (quick)"
     steps:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module periph.io/x/devices/v3
 
-go 1.13
+go 1.14
 
 require (
 	github.com/maruel/ansi256 v1.0.2


### PR DESCRIPTION
Go 1.13 was released in September 2019, more than two years ago.
Updating to one later release should be fine.

The primary reason for doing this is the introduction of
"testing".T.Cleanup in Go 1.14 (https://pkg.go.dev/testing#T.Cleanup).