### PR TITLE
waveshare2in13v2: Deduplicate and simplify logic for sending data

### DIFF
--- a/waveshare2in13v2/waveshare213v2_test.go
+++ b/waveshare2in13v2/waveshare213v2_test.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package waveshare2in13v2
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDataDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		opts       *Opts
+		wantHeight int
+		wantWidth  int
+	}{
+		{opts: &Opts{Width: 0, Height: 0}},
+		{
+			opts:       &Opts{Height: 48, Width: 16},
+			wantHeight: 48,
+			wantWidth:  2,
+		},
+		{
+			opts:       &Opts{Height: 250, Width: 122},
+			wantHeight: 250,
+			wantWidth:  16,
+		},
+	} {
+		t.Run(fmt.Sprintf("%+v", *tc.opts), func(t *testing.T) {
+			gotHeight, gotWidth := dataDimensions(tc.opts)
+
+			if !(gotHeight == tc.wantHeight && gotWidth == tc.wantWidth) {
+				t.Errorf("dataDimensions(%#v) returned %d, %d; want %d, %d", tc.opts, gotHeight, gotWidth, tc.wantHeight, tc.wantWidth)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dev.Clear: Avoid writing one beyond the end of the line. Also build the
row data only once before sending it for each line.

Dev.Draw, Dev.DrawPartial: Deduplicate logic for iterating over pixels
and simplify it such that a whole row of bits is built before sending
them in one go.

Tested using a Waveshare e-Paper 2.13in V2 display.