### PR TITLE
waveshare213v2: Add tests for clearing, use better color type

### DIFF
--- a/waveshare2in13v2/doc.go
+++ b/waveshare2in13v2/doc.go
@@ -2,14 +2,14 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package waveshare2in13v2 controls Waveshare 2in13v2 e-paper display.
+// Package waveshare2in13v2 controls Waveshare 2.13 v2 e-paper displays.
 //
-// Datasheets
-//
+// Datasheet:
 // https://www.waveshare.com/w/upload/d/d5/2.13inch_e-Paper_Specification.pdf
 //
 // Product page:
+// 2.13 inch version 2: https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
 //
-// 2.13 Inch version 2: https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
-//
+// The Waveshare 2.13in v2 display is compatible with the GoodDisplay
+// GDEH0213B73.
 package waveshare2in13v2

--- a/waveshare2in13v2/drawing.go
+++ b/waveshare2in13v2/drawing.go
@@ -5,6 +5,7 @@
 package waveshare2in13v2
 
 import (
+	"bytes"
 	"image"
 	"image/draw"
 
@@ -126,5 +127,32 @@ func drawImage(ctrl controller, opts *drawOpts) {
 		}
 
 		ctrl.sendData(rowData)
+	}
+}
+
+func clearDisplay(ctrl controller, size image.Point, color image1bit.Bit) {
+	var colorValue byte
+
+	if color == image1bit.On {
+		colorValue = 0xff
+	}
+
+	spec := (&drawOpts{
+		devSize: size,
+		dstRect: image.Rectangle{Max: size},
+	}).spec()
+
+	if spec.MemRect.Empty() {
+		return
+	}
+
+	setMemoryArea(ctrl, spec.MemRect)
+
+	ctrl.sendCommand(writeRAMBW)
+
+	data := bytes.Repeat([]byte{colorValue}, spec.MemRect.Dx())
+
+	for y := 0; y < spec.MemRect.Max.Y; y++ {
+		ctrl.sendData(data)
 	}
 }

--- a/waveshare2in13v2/waveshare213v2.go
+++ b/waveshare2in13v2/waveshare213v2.go
@@ -5,7 +5,6 @@
 package waveshare2in13v2
 
 import (
-	"bytes"
 	"fmt"
 	"image"
 	"image/color"
@@ -249,23 +248,11 @@ func (d *Dev) Init(partialUpdate PartialUpdate) error {
 }
 
 // Clear clears the display.
-func (d *Dev) Clear(color byte) error {
-	spec := (&drawOpts{
-		devSize: image.Pt(d.opts.Width, d.opts.Height),
-		dstRect: d.Bounds(),
-	}).spec()
-
+func (d *Dev) Clear(color color.Color) error {
 	eh := errorHandler{d: *d}
 
-	setMemoryArea(&eh, spec.MemRect)
-
-	eh.sendCommand(writeRAMBW)
-
-	data := bytes.Repeat([]byte{color}, spec.MemRect.Dx())
-
-	for y := 0; y < spec.MemRect.Max.Y; y++ {
-		eh.sendData(data)
-	}
+	clearDisplay(&eh, image.Pt(d.opts.Width, d.opts.Height),
+		image1bit.BitModel.Convert(color).(image1bit.Bit))
 
 	if eh.err == nil {
 		eh.err = d.turnOnDisplay()
@@ -335,7 +322,7 @@ func (d *Dev) DrawPartial(dstRect image.Rectangle, src image.Image, srcPts image
 
 // Halt clears the display.
 func (d *Dev) Halt() error {
-	return d.Clear(0xFF)
+	return d.Clear(image1bit.On)
 }
 
 // String returns a string containing configuration information.

--- a/waveshare2in13v2/waveshare213v2.go
+++ b/waveshare2in13v2/waveshare213v2.go
@@ -261,7 +261,7 @@ func (d *Dev) Clear(color byte) error {
 
 	eh.sendCommand(writeRAMBW)
 
-	data := bytes.Repeat([]byte{color}, spec.MemRect.Dy())
+	data := bytes.Repeat([]byte{color}, spec.MemRect.Dx())
 
 	for y := 0; y < spec.MemRect.Max.Y; y++ {
 		eh.sendData(data)


### PR DESCRIPTION
This is an API-breaking change, albeit a simple one: Previously the `Dev.Clear` function received a byte named "color". It was sent directly to the display, thus acting more like a pattern to fill the display with. In practice only 0 and 255 are likely to be used (equivalent to `image1bit.Off` and `image1bit.On` respectively). To match the `Dev.Draw` interface a generic `color.Color` is now used.