### PR TITLE
waveshare213v2: Make busy a PinIn, use WaitForEdge

### DIFF
--- a/waveshare2in13v2/errorhandler.go
+++ b/waveshare2in13v2/errorhandler.go
@@ -45,8 +45,8 @@ func (eh *errorHandler) csOut(l gpio.Level) {
 }
 
 func (eh *errorHandler) waitUntilIdle() {
-	for eh.d.busy.Read() == gpio.High {
-		time.Sleep(100 * time.Millisecond)
+	for busy := eh.d.busy; busy.Read() == gpio.High; {
+		busy.WaitForEdge(100 * time.Millisecond)
 	}
 }
 

--- a/waveshare2in13v2/waveshare213v2.go
+++ b/waveshare2in13v2/waveshare213v2.go
@@ -60,7 +60,7 @@ type Dev struct {
 	dc   gpio.PinOut
 	cs   gpio.PinOut
 	rst  gpio.PinOut
-	busy gpio.PinIO
+	busy gpio.PinIn
 
 	opts *Opts
 }
@@ -123,9 +123,13 @@ var EPD2in13v2 = Opts{
 }
 
 // New creates new handler which is used to access the display.
-func New(p spi.Port, dc, cs, rst gpio.PinOut, busy gpio.PinIO, opts *Opts) (*Dev, error) {
+func New(p spi.Port, dc, cs, rst gpio.PinOut, busy gpio.PinIn, opts *Opts) (*Dev, error) {
 	c, err := p.Connect(5*physic.MegaHertz, spi.Mode0, 8)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := busy.In(gpio.Float, gpio.FallingEdge); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The busy pin from the e-paper display is only used to read, not to
write, and thus there's no need for the PinIO interface. PinIn is
enough.

In addition the WaitForEdge function can be used to shorten the delays
when waiting for the display to become idle. Spurious or missed edges
are acceptable: the delay isn't very long.