### PR TITLE
waveshare2in13v2: Clarify documentation on controller

### DIFF
--- a/waveshare2in13v2/doc.go
+++ b/waveshare2in13v2/doc.go
@@ -10,6 +10,8 @@
 // Product page:
 // 2.13 inch version 2: https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
 //
-// The Waveshare 2.13in v2 display is compatible with the GoodDisplay
-// GDEH0213B73.
+// The Waveshare 2.13in v2 display is a GoodDisplay GDEH0213B72. Its IL3897
+// controller is compatible with the SSD1675A (sometimes also referred to as
+// SSD1675). The SSD1675A should not be mixed up with the SSD1675B. They have
+// different LUT formats (70 bytes for SSD1675A, 100 bytes for SSD1675B).
 package waveshare2in13v2


### PR DESCRIPTION
Additional research provided information confirming that Waveshare
2.13in v2 displays are in fact GDEH0213B72, not GDEH0213B73, or at least
equivalent.