### PR TITLE
Minor fixes for waveshare2in13v2, fix typos in image1bit

### DIFF
--- a/ssd1306/image1bit/image1bit.go
+++ b/ssd1306/image1bit/image1bit.go
@@ -49,8 +49,8 @@ var BitModel = color.ModelFunc(convert)
 
 // VerticalLSB is a 1 bit (black and white) image.
 //
-// Each byte is 8 vertical pixels. Each stride is an horizontal band of 8
-// pixels high with LSB first. So the first byte represent the following
+// Each byte is 8 vertical pixels. Each stride is a horizontal band of 8
+// pixels high with LSB first. So the first byte represents the following
 // pixels, with lowest bit being the top left pixel.
 //
 //   0 x x x x x x x
@@ -62,7 +62,7 @@ var BitModel = color.ModelFunc(convert)
 //   6 x x x x x x x
 //   7 x x x x x x x
 //
-// It is designed specifically to work with SSD1306 OLED display controler.
+// It is designed specifically to work with SSD1306 OLED display controller.
 type VerticalLSB struct {
 	// Pix holds the image's pixels, as vertically LSB-first packed bitmap. It
 	// can be passed directly to ssd1306.Dev.Write()

--- a/waveshare2in13v2/waveshare213v2.go
+++ b/waveshare2in13v2/waveshare213v2.go
@@ -281,7 +281,9 @@ func (d *Dev) Halt() error {
 
 // String returns a string containing configuration information.
 func (d *Dev) String() string {
-	return fmt.Sprintf("epd.Dev{%s, %s, Height: %d, Width: %d}", d.c, d.dc, d.opts.Height, d.opts.Width)
+	bounds := d.Bounds()
+
+	return fmt.Sprintf("epd.Dev{%s, %s, Width: %d, Height: %d}", d.c, d.dc, bounds.Dx(), bounds.Dy())
 }
 
 // Sleep makes the controller enter deep sleep mode. It can be woken up by

--- a/waveshare2in13v2/waveshare213v2_test.go
+++ b/waveshare2in13v2/waveshare213v2_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package waveshare2in13v2
+
+import (
+	"image"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"periph.io/x/conn/v3/gpio"
+	"periph.io/x/conn/v3/gpio/gpiotest"
+	"periph.io/x/conn/v3/spi/spitest"
+	"periph.io/x/devices/v3/ssd1306/image1bit"
+)
+
+func TestNew(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		opts             Opts
+		wantString       string
+		wantBounds       image.Rectangle
+		wantBufferBounds image.Rectangle
+	}{
+		{
+			name:       "empty",
+			wantString: "epd.Dev{playback, (0), Height: 0, Width: 0}",
+		},
+		{
+			name:             "EPD2in13v2",
+			opts:             EPD2in13v2,
+			wantBounds:       image.Rect(0, 0, 122, 250),
+			wantBufferBounds: image.Rect(0, 0, 128, 250),
+			wantString:       "epd.Dev{playback, (0), Height: 250, Width: 122}",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dev, err := New(&spitest.Playback{}, &gpiotest.Pin{}, &gpiotest.Pin{}, &gpiotest.Pin{}, &gpiotest.Pin{
+				EdgesChan: make(chan gpio.Level, 1),
+			}, &tc.opts)
+			if err != nil {
+				t.Errorf("New() failed: %v", err)
+			}
+
+			if diff := cmp.Diff(dev.String(), tc.wantString); diff != "" {
+				t.Errorf("String() difference (-got +want):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(dev.Bounds(), tc.wantBounds); diff != "" {
+				t.Errorf("Bounds() difference (-got +want):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(dev.buffer.Bounds(), tc.wantBufferBounds); diff != "" {
+				t.Errorf("buffer.Bounds() difference (-got +want):\n%s", diff)
+			}
+
+			if !dev.buffer.Bounds().Empty() {
+				for _, pos := range []image.Point{
+					image.Pt(0, 0),
+					image.Pt(dev.buffer.Bounds().Max.X-1, 0),
+					image.Pt(dev.buffer.Bounds().Max.X-1, dev.buffer.Bounds().Max.Y-1),
+					image.Pt(0, dev.buffer.Bounds().Max.Y-1),
+					image.Pt(dev.buffer.Bounds().Dx()/2, dev.buffer.Bounds().Dy()/2),
+				} {
+					if diff := cmp.Diff(dev.buffer.BitAt(pos.X, pos.Y), image1bit.On); diff != "" {
+						t.Errorf("buffer.BitAt(%v) difference (-got +want):\n%s", pos, diff)
+					}
+				}
+			}
+		})
+	}
+}

--- a/waveshare2in13v2/waveshare213v2_test.go
+++ b/waveshare2in13v2/waveshare213v2_test.go
@@ -25,14 +25,14 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name:       "empty",
-			wantString: "epd.Dev{playback, (0), Height: 0, Width: 0}",
+			wantString: "epd.Dev{playback, (0), Width: 0, Height: 0}",
 		},
 		{
 			name:             "EPD2in13v2",
 			opts:             EPD2in13v2,
 			wantBounds:       image.Rect(0, 0, 122, 250),
 			wantBufferBounds: image.Rect(0, 0, 128, 250),
-			wantString:       "epd.Dev{playback, (0), Height: 250, Width: 122}",
+			wantString:       "epd.Dev{playback, (0), Width: 122, Height: 250}",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
* Add tests for `waveshare2in13v2.New()`
* Swap the order of width and height in `waveshare2in13v2.Dev.String()`
* Simplify memory configuration