### PR TITLE
tlv493d: Auto-reset TLV493D on error

### DIFF
--- a/tlv493d/tlv493d.go
+++ b/tlv493d/tlv493d.go
@@ -405,14 +405,16 @@ func (d *Dev) ReadContinuous(frequency physic.Frequency, precision Precision) (<
 				if err != nil {
 					// Try resetting the sensor to recover from errors
 					fmt.Println("Error reading from TLV493D sensor:", err)
-					if err := d.initialize(true); err != nil {
-						continue
+					if err := d.initialize(true); err == nil {
+						if err := d.SetMode(newMode); err != nil {
+							fmt.Println("Unable to reset TLV493D mode:", err)
+						} else {
+							fmt.Println("Sensor reset successfully")
+						}
 					}
-					d.SetMode(newMode)
-					fmt.Println("Sensor reset successfully")
-				} else {
-					reading <- value
+					continue
 				}
+				reading <- value
 			}
 		}
 	}(d.stop)

--- a/tlv493d/tlv493d.go
+++ b/tlv493d/tlv493d.go
@@ -405,13 +405,14 @@ func (d *Dev) ReadContinuous(frequency physic.Frequency, precision Precision) (<
 				if err != nil {
 					// Try resetting the sensor to recover from errors
 					fmt.Println("Error reading from TLV493D sensor:", err)
-					if err := d.initialize(true); err == nil {
-						d.SetMode(newMode)
-						fmt.Println("Sensor reset successfully")
+					if err := d.initialize(true); err != nil {
+						continue
 					}
-					continue
+					d.SetMode(newMode)
+					fmt.Println("Sensor reset successfully")
+				} else {
+					reading <- value
 				}
-				reading <- value
 			}
 		}
 	}(d.stop)

--- a/tlv493d/tlv493d.go
+++ b/tlv493d/tlv493d.go
@@ -7,6 +7,7 @@ package tlv493d
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -404,12 +405,11 @@ func (d *Dev) ReadContinuous(frequency physic.Frequency, precision Precision) (<
 				value, err := d.Read(precision)
 				if err != nil {
 					// Try resetting the sensor to recover from errors
-					fmt.Println("Error reading from TLV493D sensor:", err)
 					if err := d.initialize(true); err == nil {
 						if err := d.SetMode(newMode); err != nil {
-							fmt.Println("Unable to reset TLV493D mode:", err)
+							log.Println("Unable to reset TLV493D mode:", err)
 						} else {
-							fmt.Println("Sensor reset successfully")
+							log.Println("Sensor reset successfully")
 						}
 					}
 					continue

--- a/tlv493d/tlv493d.go
+++ b/tlv493d/tlv493d.go
@@ -185,7 +185,7 @@ func New(i i2c.Bus, opts *Opts) (*Dev, error) {
 		temperatureOffsetCompensation: opts.TemperatureOffsetCompensation,
 		registersBuffer:               make([]byte, numberOfReadRegisters),
 	}
-	if err := d.initialize(opts); err != nil {
+	if err := d.initialize(opts.Reset); err != nil {
 		return nil, err
 	}
 	return d, nil
@@ -204,7 +204,7 @@ func (d *Dev) Halt() error {
 	return d.SetMode(PowerDownMode)
 }
 
-func (d *Dev) initialize(opts *Opts) error {
+func (d *Dev) initialize(reset bool) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -215,7 +215,7 @@ func (d *Dev) initialize(opts *Opts) error {
 		return err
 	}
 
-	if opts.Reset {
+	if reset {
 		// Reset I2C address
 		var resetAddress byte = 0x00
 		if d.i2c.Addr == I2CAddr1 {
@@ -403,7 +403,12 @@ func (d *Dev) ReadContinuous(frequency physic.Frequency, precision Precision) (<
 			case <-t.C:
 				value, err := d.Read(precision)
 				if err != nil {
-					// In continuous mode, we'll ignore errors silently.
+					// Try resetting the sensor to recover from errors
+					fmt.Println("Error reading from TLV493D sensor:", err)
+					if err := d.initialize(true); err == nil {
+						d.SetMode(newMode)
+						fmt.Println("Sensor reset successfully")
+					}
 					continue
 				}
 				reading <- value


### PR DESCRIPTION
When an error occurs, it is necessary to reset the sensor as per the documentation. This will send a recovery command followed by the standard start procedure.