### PR TITLE
lirc requries linebreak \n for SEND_ONCE

### DIFF
--- a/lirc/lirc.go
+++ b/lirc/lirc.go
@@ -64,7 +64,7 @@ func (c *Conn) Close() error {
 // Emit implements ir.IR.
 func (c *Conn) Emit(remote string, key ir.Key) error {
 	// http://www.lirc.org/html/lircd.html#lbAH
-	_, err := fmt.Fprintf(c.w, "SEND_ONCE %s %s", remote, key)
+	_, err := fmt.Fprintf(c.w, "SEND_ONCE %s %s\n", remote, key)
 	return err
 }
 


### PR DESCRIPTION
1. Please prefix the issue title with the primary package affected. For example,
Fixes periph.io/x/devices/v3/devices/lirc/lirc.go:67

2. Mention the issue number it fixes or add the details of the changes if it
doesn't have a specific issue. Examples:
- Fixes #56

P.S. There's already another issue when the command is sent successfully but the parse of lirc.go cannot recognize it the the SEND_ONCE trigger a raw config. I will fill another issue once I have the solution.