### PR TITLE
Add AHT20 tests

### DIFF
--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -1,0 +1,36 @@
+package aht20
+
+import (
+	"periph.io/x/conn/v3/i2c"
+	"periph.io/x/conn/v3/i2c/i2ctest"
+	"periph.io/x/conn/v3/physic"
+	"testing"
+)
+
+func TestDev_Sense(t *testing.T) {
+	bus := i2ctest.Playback{
+		Ops: []i2ctest.IO{
+			// Trigger measurement
+			{Addr: deviceAddress, W: argsMeasure},
+			// Read measurement
+			{Addr: deviceAddress, R: []byte{0x18, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x7F}},
+		},
+	}
+	dev := Dev{d: &i2c.Dev{Bus: &bus, Addr: deviceAddress}, opts: DefaultOpts}
+	e := physic.Env{}
+	if err := dev.Sense(&e); err != nil {
+		t.Fatal(err)
+	}
+	if expected := 19445800781*physic.NanoKelvin + physic.ZeroCelsius; e.Temperature != expected {
+		t.Fatalf("temperature %s(%d) != %s(%d)", expected, expected, e.Temperature, e.Temperature)
+	}
+	if expected := 4582824 * physic.TenthMicroRH; e.Humidity != expected {
+		t.Fatalf("humidity %s(%d) != %s(%d)", expected, expected, e.Humidity, e.Humidity)
+	}
+	if expected := 0 * physic.Pascal; e.Pressure != expected {
+		t.Fatalf("pressure %s(%d) != %s(%d)", expected, expected, e.Pressure, e.Pressure)
+	}
+	if err := bus.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -9,7 +9,6 @@ import (
 	"periph.io/x/conn/v3/i2c/i2ctest"
 	"periph.io/x/conn/v3/physic"
 	"testing"
-	"time"
 )
 
 const byteStatusInitialized = bitInitialized | 0x10
@@ -139,10 +138,10 @@ func TestDev_Sense_error(t *testing.T) {
 		},
 		{
 			name: "read timeout",
-			data: []byte{byteStatusInitialized, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x7F},
+			data: []byte{bitInitialized | bitBusy, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x16},
 			opts: Opts{
 				MeasurementReadTimeout:  1,
-				MeasurementWaitInterval: 10 * time.Millisecond,
+				MeasurementWaitInterval: -1,
 				ValidateData:            true,
 			},
 			error: &ReadTimeoutError{1},

--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -125,7 +125,6 @@ func TestDev_Sense_error(t *testing.T) {
 	type TestCase struct {
 		name  string
 		data  []byte
-		opts  Opts
 		error error
 	}
 
@@ -133,13 +132,11 @@ func TestDev_Sense_error(t *testing.T) {
 		{
 			name:  "data corrupt",
 			data:  []byte{byteStatusInitialized, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x7E},
-			opts:  DefaultOpts,
 			error: &DataCorruptionError{0x7F, 0x7E},
 		},
 		{
 			name:  "not initialized",
 			data:  []byte{0x00, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x20},
-			opts:  DefaultOpts,
 			error: &NotInitializedError{},
 		},
 	}
@@ -154,7 +151,7 @@ func TestDev_Sense_error(t *testing.T) {
 					{Addr: deviceAddress, R: tc.data},
 				},
 			}
-			dev := Dev{d: &i2c.Dev{Bus: &bus, Addr: deviceAddress}, opts: tc.opts}
+			dev := Dev{d: &i2c.Dev{Bus: &bus, Addr: deviceAddress}, opts: DefaultOpts}
 			e := physic.Env{}
 			if err := dev.Sense(&e); err == nil {
 				t.Fatal("expected error")

--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
 package aht20
 
 import (

--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -139,7 +139,7 @@ func TestDev_Sense_error(t *testing.T) {
 		},
 		{
 			name: "read timeout",
-			data: []byte{0x00, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x7F},
+			data: []byte{byteStatusInitialized, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x7F},
 			opts: Opts{
 				MeasurementReadTimeout:  1,
 				MeasurementWaitInterval: 10 * time.Millisecond,

--- a/aht20/aht20_test.go
+++ b/aht20/aht20_test.go
@@ -137,16 +137,6 @@ func TestDev_Sense_error(t *testing.T) {
 			error: &DataCorruptionError{0x7F, 0x7E},
 		},
 		{
-			name: "read timeout",
-			data: []byte{bitInitialized | bitBusy, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x16},
-			opts: Opts{
-				MeasurementReadTimeout:  1,
-				MeasurementWaitInterval: -1,
-				ValidateData:            true,
-			},
-			error: &ReadTimeoutError{1},
-		},
-		{
 			name:  "not initialized",
 			data:  []byte{0x00, 0x75, 0x52, 0x05, 0x8E, 0x40, 0x20},
 			opts:  DefaultOpts,


### PR DESCRIPTION
- Add tests for all exported methods of the AHT20 device (except `SenseContinuous()`)
- Fix `IsInitialized()` always returning `false` due to data byte not being set