### PR TITLE
periph.io/x/devices/v3/bmxx80: add support for filters without using SenseContinuous

### DIFF
--- a/bmxx80/bmx280.go
+++ b/bmxx80/bmx280.go
@@ -75,7 +75,7 @@ const (
 // measurements are done.
 type standby uint8
 
-// Possible standby values, these determines the refresh rate.
+// Possible standby values, these determine the refresh rate.
 const (
 	s500us   standby = 0
 	s10msBME standby = 6

--- a/bmxx80/bmx280_test.go
+++ b/bmxx80/bmx280_test.go
@@ -7,7 +7,7 @@ package bmxx80
 import (
 	"errors"
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -1028,7 +1028,7 @@ func (s *spiFail) Connect(f physic.Frequency, mode spi.Mode, bits int) (spi.Conn
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 	os.Exit(m.Run())
 }

--- a/bmxx80/doc.go
+++ b/bmxx80/doc.go
@@ -32,6 +32,6 @@
 //
 // The results of the calculations in the algorithm on page 15 are partly
 // wrong. It looks like the original authors used non-integer calculations and
-// some nubers were rounded. Take the results of the calculations with a grain
+// some numbers were rounded. Take the results of the calculations with a grain
 // of salt.
 package bmxx80


### PR DESCRIPTION
I cannot use the `SenseContinuous` option with my hardware as there are additional bus contention issues to deal with, but would like to use the built in filtering on the BME sensors. 

In order to prevent current implementations from changing their behavior I added a new initialization option to set the standby time. When the `Filter` and `Standby` options are set in the device options the sensor will initialize to the `normal` mode instead of `sleep`. Additionally when calling `Sense` mode will not be set to `forced` if the `Filter` and `Standby` options are set as this would prevent the continuous sampling needing for the filtration. 