### PR TITLE
[inky] Add Inky Impression 7.3" support

### DIFF
--- a/inky/doc.go
+++ b/inky/doc.go
@@ -11,5 +11,6 @@
 // https://github.com/pimoroni/inky
 //
 // The display seems to use a SSD1675 controller:
+//
 // https://www.china-epaper.com/uploads/soft/DEPG0420R01V3.0.pdf
 package inky

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -406,6 +406,8 @@ func (d *DevImpression) resetUC() error {
 }
 
 func (d *DevImpression) resetAC() error {
+	// Reference code: https://github.com/pimoroni/inky/blob/a7d380231cc5fac754243b8d66d2c5674c1bd1ac/inky/inky_ac073tc1a.py#L229
+
 	if err := d.cycleResetGPIO(); err != nil {
 		return err
 	}

--- a/inky/types.go
+++ b/inky/types.go
@@ -21,6 +21,7 @@ const (
 	PHAT2
 	IMPRESSION4
 	IMPRESSION57
+	IMPRESSION73
 )
 
 // Set sets the Model to a value represented by the string s. Set implements the flag.Value interface.
@@ -36,8 +37,10 @@ func (m *Model) Set(s string) error {
 		*m = IMPRESSION4
 	case "IMPRESSION57":
 		*m = IMPRESSION57
+	case "IMPRESSION73":
+		*m = IMPRESSION73
 	default:
-		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4 or IMPRESSION57", s)
+		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4 or IMPRESSION57 or IMPRESSION73", s)
 	}
 	return nil
 }

--- a/inky/types.go
+++ b/inky/types.go
@@ -40,7 +40,7 @@ func (m *Model) Set(s string) error {
 	case "IMPRESSION73":
 		*m = IMPRESSION73
 	default:
-		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4 or IMPRESSION57 or IMPRESSION73", s)
+		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4, IMPRESSION57 or IMPRESSION73", s)
 	}
 	return nil
 }

--- a/inky/types_string.go
+++ b/inky/types_string.go
@@ -13,11 +13,12 @@ func _() {
 	_ = x[PHAT2-2]
 	_ = x[IMPRESSION4-3]
 	_ = x[IMPRESSION57-4]
+	_ = x[IMPRESSION73-5]
 }
 
-const _Model_name = "PHATWHATPHAT2IMPRESSION4IMPRESSION57"
+const _Model_name = "PHATWHATPHAT2IMPRESSION4IMPRESSION57IMPRESSION73"
 
-var _Model_index = [...]uint8{0, 4, 8, 13, 24, 36}
+var _Model_index = [...]uint8{0, 4, 8, 13, 24, 36, 48}
 
 func (i Model) String() string {
 	if i < 0 || i >= Model(len(_Model_index)-1) {


### PR DESCRIPTION
Inky Impression 7.3" is a larger e-ink display that unlike smaller variants is based on AC073TC1A rather than UC8159.

This PR is effectively a port of pimoroni/inky#158 since the difference is primarily in the reset and update commads.

(draft until I have a chance to properly test)