### PR TITLE
inky: run stringer with "go run"

### DIFF
--- a/inky/types.go
+++ b/inky/types.go
@@ -4,7 +4,7 @@
 
 package inky
 
-//go:generate go install golang.org/x/tools/cmd/stringer@latest
+//go:generate -command stringer go run golang.org/x/tools/cmd/stringer@latest
 //go:generate stringer -type=Model,Color,ImpressionColor -output types_string.go
 
 import (


### PR DESCRIPTION
Run the `stringer` command (for code generation) using `go run` instead of `go install` to avoid affecting the developer's global `$GOBIN`.