### PR TITLE
inky/impression: fix init of bounds

### DIFF
--- a/inky/impression.go
+++ b/inky/impression.go
@@ -205,7 +205,7 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 		d.res = 0b11
 	}
 	// Prefer the passed in values via Opts.
-	if o.Width == 0 && o.Height == 0 {
+	if o.Width != 0 && o.Height != 0 {
 		d.width = o.Width
 		d.height = o.Height
 	}


### PR DESCRIPTION
Fix typo in initialization of bounds when bounds are not explicitely set by the user.

This issue has been reported by @kedare in https://github.com/periph/devices/pull/75#issuecomment-2692847224

Cc: @fstanis @gsexton