### PR TITLE
inky: Fix Impression Driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	golang.org/x/image v0.23.0
 	periph.io/x/conn/v3 v3.7.2
-	periph.io/x/host/v3 v3.8.4
+	periph.io/x/host/v3 v3.8.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,5 +17,5 @@ golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 periph.io/x/conn/v3 v3.7.2 h1:qt9dE6XGP5ljbFnCKRJ9OOCoiOyBGlw7JZgoi72zZ1s=
 periph.io/x/conn/v3 v3.7.2/go.mod h1:Ao0b4sFRo4QOx6c1tROJU1fLJN1hUIYggjOrkIVnpGg=
-periph.io/x/host/v3 v3.8.4 h1:QNleTythDd0k6Chu0n+ISrJFlf3LFig9oNbtOIkxoCc=
-periph.io/x/host/v3 v3.8.4/go.mod h1:hPq8dISZIc+UNfWoRj+bPH3XEBQqJPdFdx218W92mdc=
+periph.io/x/host/v3 v3.8.5 h1:g4g5xE1XZtDiGl1UAJaUur1aT7uNiFLMkyMEiZ7IHII=
+periph.io/x/host/v3 v3.8.5/go.mod h1:hPq8dISZIc+UNfWoRj+bPH3XEBQqJPdFdx218W92mdc=

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -17,7 +17,6 @@ import (
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/display"
 	"periph.io/x/conn/v3/gpio"
-	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"
 )
@@ -160,7 +159,7 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 	// is 192K Bytes. To make the Impression 7.3 treat this as single trans-
 	// action, we have to take over control of the CS pin and manipulate it
 	// as required.
-	c, err := p.Connect(cSpeed, spi.Mode0|spi.NoCS, 8)
+	c, err := p.Connect(cSpeed, spi.Mode0, 8)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to inky over spi: %v", err)
 	}
@@ -191,7 +190,6 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 			model:      o.Model,
 			variant:    o.DisplayVariant,
 			pcbVariant: o.PCBVariant,
-			cs:         gpioreg.ByName(cs0Pin),
 		},
 		saturation: 50, // Looks good enough for most of the images.
 	}

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -156,10 +156,6 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 	if o.Model == IMPRESSION73 {
 		cSpeed = acSpeed
 	}
-	// The SPI driver has a max buffer size of 4K bytes, but our image size
-	// is 192K Bytes. To make the Impression 7.3 treat this as single trans-
-	// action, we have to take over control of the CS pin and manipulate it
-	// as required.
 	c, err := p.Connect(cSpeed, spi.Mode0, 8)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to inky over spi: %v", err)

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -160,7 +160,7 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 	// is 192K Bytes. To make the Impression 7.3 treat this as single trans-
 	// action, we have to take over control of the CS pin and manipulate it
 	// as required.
-	c, err := p.Connect(cSpeed, spi.Mode0|spi.NoCS, cs0Pin)
+	c, err := p.Connect(cSpeed, spi.Mode0|spi.NoCS, 8)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to inky over spi: %v", err)
 	}
@@ -191,7 +191,7 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 			model:      o.Model,
 			variant:    o.DisplayVariant,
 			pcbVariant: o.PCBVariant,
-			cs:         gpioreg.ByName("GPIO8"),
+			cs:         gpioreg.ByName(cs0Pin),
 		},
 		saturation: 50, // Looks good enough for most of the images.
 	}

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -584,7 +584,7 @@ func (d *DevImpression) wait(dur time.Duration) {
 				return
 			}
 			// It was a bounce. Recalculate the duration to wait for the edge.
-			edgeDur = tEnd.Sub(time.Now())
+			edgeDur = time.Until(tEnd)
 		}
 	}
 }

--- a/inky/impression.go
+++ b/inky/impression.go
@@ -17,6 +17,7 @@ import (
 	"periph.io/x/conn/v3"
 	"periph.io/x/conn/v3/display"
 	"periph.io/x/conn/v3/gpio"
+	"periph.io/x/conn/v3/gpio/gpioreg"
 	"periph.io/x/conn/v3/physic"
 	"periph.io/x/conn/v3/spi"
 )
@@ -177,6 +178,11 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 			maxTxSize = 4096 // Use a conservative default.
 		}
 	}
+	// If possible, grab the CS pin.
+	cs := gpioreg.ByName(cs0Pin)
+	if cs != nil && cs.Out(csDisabled) != nil {
+		cs = nil
+	}
 
 	d := &DevImpression{
 		Dev: Dev{
@@ -190,6 +196,7 @@ func NewImpression(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinI
 			model:      o.Model,
 			variant:    o.DisplayVariant,
 			pcbVariant: o.PCBVariant,
+			cs:         cs,
 		},
 		saturation: 50, // Looks good enough for most of the images.
 	}

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -351,7 +351,11 @@ func (d *Dev) sendCommand(command byte, data []byte) (err error) {
 		err = fmt.Errorf("inky: failed to send command %x to inky: %v", command, err)
 		return
 	}
-	d.cs.Out(gpio.High)
+	err = d.cs.Out(gpio.High)
+	if err != nil {
+		return err
+	}
+
 	if data != nil {
 		if err = d.sendData(data); err != nil {
 			err = fmt.Errorf("inky: failed to send data for command %x to inky: %v", command, err)

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -23,7 +23,7 @@ var _ display.Drawer = &Dev{}
 var _ conn.Resource = &Dev{}
 
 const (
-	cs0Pin = 8
+	cs0Pin = "GPIO8"
 )
 
 var borderColor = map[Color]byte{
@@ -75,7 +75,7 @@ func New(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinIn, o *Opts
 		return nil, fmt.Errorf("unsupported color: %v", o.ModelColor)
 	}
 
-	c, err := p.Connect(488*physic.KiloHertz, spi.Mode0, cs0Pin)
+	c, err := p.Connect(488*physic.KiloHertz, spi.Mode0 | spi.NoCS, 8)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to inky over spi: %v", err)
 	}
@@ -101,7 +101,7 @@ func New(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinIn, o *Opts
 		model:      o.Model,
 		variant:    o.DisplayVariant,
 		pcbVariant: o.PCBVariant,
-		cs:         gpioreg.ByName("GPIO8"),
+		cs:         gpioreg.ByName(cs0Pin),
 	}
 
 	switch o.Model {

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -75,7 +75,7 @@ func New(p spi.Port, dc gpio.PinOut, reset gpio.PinOut, busy gpio.PinIn, o *Opts
 		return nil, fmt.Errorf("unsupported color: %v", o.ModelColor)
 	}
 
-	c, err := p.Connect(488*physic.KiloHertz, spi.Mode0 | spi.NoCS, 8)
+	c, err := p.Connect(488*physic.KiloHertz, spi.Mode0|spi.NoCS, 8)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to inky over spi: %v", err)
 	}

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -412,9 +412,6 @@ func (d *Dev) sendData(data []byte) (err error) {
 		}
 	}
 	err = d.setCSPin(csDisabled)
-	if err != nil {
-		return
-	}
 	return
 }
 

--- a/inky/inky.go
+++ b/inky/inky.go
@@ -364,7 +364,7 @@ func (d *Dev) setCSPin(mode gpio.Level) error {
 }
 
 func (d *Dev) sendCommand(command byte, data []byte) (err error) {
-	d.setCSPin(csEnabled)
+	err = d.setCSPin(csEnabled)
 	if err != nil {
 		return
 	}

--- a/inky/types.go
+++ b/inky/types.go
@@ -69,6 +69,8 @@ func (c *Color) Set(s string) error {
 		*c = Yellow
 	case "white":
 		*c = White
+	case "multi":
+		*c = Multi
 	default:
 		return fmt.Errorf("unknown color %q: expected either black, red, yellow or white", s)
 	}


### PR DESCRIPTION
Fixes #105

This PR fixes issues in the Inky 7.3 Impression Driver.

* Changed the SPI CS pin to work under automatic or manual control. This allows it to work when CS is controlled by SPI, or when it is controlled manually. We don't want it to fail in the configuration the Pimoroni python driver requires.
* Changed the wait() routine to use a 10ms debounce on WaitForEdge() as the python driver does. 
* Fixed an issue in the image copy where the image byte wasn't copied (see line 530 of impression.go).
* If the BUSY line is high on entry to wait to go directly to a timed wait as the python driver does.
* Fixed errors in the palette definitions. Removed extra memory allocation.

