### PR TITLE
inky: Add Impression 7.3 Spectra6 support

### DIFF
--- a/inky/opts.go
+++ b/inky/opts.go
@@ -34,6 +34,7 @@ var (
 		"Red wHAT (SSD1683)",
 		"Yellow wHAT (SSD1683)",
 		"7-Colour 800x480 (AC073TC1A)",
+		"Spectra 6 7.3 800 x 480 (E673)",
 	}
 )
 
@@ -78,7 +79,7 @@ func DetectOpts(bus i2c.Bus) (*Opts, error) {
 	case 3:
 		options.ModelColor = Yellow
 		options.BorderColor = Yellow
-	case 4:
+	case 4, 6:
 		options.ModelColor = Multi
 		options.BorderColor = Color(WhiteImpression)
 	default:
@@ -100,6 +101,8 @@ func DetectOpts(bus i2c.Bus) (*Opts, error) {
 		options.Model = IMPRESSION4
 	case 20:
 		options.Model = IMPRESSION73
+	case 22:
+		options.Model = IMPRESSION73SPECTRA6
 	default:
 		return nil, fmt.Errorf("failed to get ops: display type %v not supported", data[6])
 	}

--- a/inky/types.go
+++ b/inky/types.go
@@ -22,6 +22,7 @@ const (
 	IMPRESSION4
 	IMPRESSION57
 	IMPRESSION73
+	IMPRESSION73SPECTRA6
 )
 
 // Set sets the Model to a value represented by the string s. Set implements the [flag.Value] interface.
@@ -39,8 +40,10 @@ func (m *Model) Set(s string) error {
 		*m = IMPRESSION57
 	case "IMPRESSION73":
 		*m = IMPRESSION73
+	case "IMPRESSION73SPECTRA6":
+		*m = IMPRESSION73SPECTRA6
 	default:
-		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4, IMPRESSION57 or IMPRESSION73", s)
+		return fmt.Errorf("unknown model %q: expected PHAT, PHAT2, WHAT, IMPRESSION4, IMPRESSION57, IMPRESSION73, or IMPRESSION73SPECTRA6", s)
 	}
 	return nil
 }

--- a/inky/types_string.go
+++ b/inky/types_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[IMPRESSION4-3]
 	_ = x[IMPRESSION57-4]
 	_ = x[IMPRESSION73-5]
+	_ = x[IMPRESSION73SPECTRA6-6]
 }
 
-const _Model_name = "PHATWHATPHAT2IMPRESSION4IMPRESSION57IMPRESSION73"
+const _Model_name = "PHATWHATPHAT2IMPRESSION4IMPRESSION57IMPRESSION73IMPRESSION73SPECTRA6"
 
-var _Model_index = [...]uint8{0, 4, 8, 13, 24, 36, 48}
+var _Model_index = [...]uint8{0, 4, 8, 13, 24, 36, 48, 68}
 
 func (i Model) String() string {
 	if i < 0 || i >= Model(len(_Model_index)-1) {


### PR DESCRIPTION
- Ported the [Python driver for the 2025 version of the Inky Impression 7.3 based on eInk Spectra 6](https://github.com/pimoroni/inky/blob/fef67aab73bb2b6def1eca6003a3f5a3ccec0741/inky/inky_e673.py)
- Updated the Inky options to auto-detect the Spectra6 version of the display

I only have the 7.3-inch version to test, so this PR omits adding support for the 13 inch version of the display, but I imagine that would not be complicated to support.